### PR TITLE
Fixes a typo and formatting error in the sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Documentation about the framework can be found here: [Modern Valo Extensibility 
 Once the solution is deployed on your tenant, you can add it manually like this (uses the Office 365 CLI):
 
 ```
-o365 spo customaction add -t "custom-valo-ui-extensions" -c 7d190fa2-c4ae-42b2-8537-431bf7bb8b41-u https://<your-site-URL> -l "ClientSideExtension.ApplicationCustomizer" -n "custom-valo-ui-extension"
+o365 spo customaction add -t "custom-valo-ui-extensions" -c 7d190fa2-c4ae-42b2-8537-431bf7bb8b41 -u https://<your-site-URL> -l "ClientSideExtension.ApplicationCustomizer" -n "custom-valo-ui-extension"
 ```
-
-
-m365 spo customaction add --name 'ValoCustomToolboxAction' --title "custom-valo-ui-extensions" --location "ClientSideExtension.ApplicationCustomizer" --clientSideComponentId 7d190fa2-c4ae-42b2-8537-431bf7bb8b41 --clientSideComponentProperties '{}' --url "https://simedev027.sharepoint.com/sites/tea-point-whats-new"
+Or:
+```
+m365 spo customaction add --name 'ValoCustomToolboxAction' --title "custom-valo-ui-extensions" --location "ClientSideExtension.ApplicationCustomizer" --clientSideComponentId 7d190fa2-c4ae-42b2-8537-431bf7bb8b41 --clientSideComponentProperties '{}' --url "https://<your-site-URL>"
+```


### PR DESCRIPTION
Heyo! Sorry to randomly edit the documentation like this, but I noticed the formatting of the sample command wasn't quite there. I fixed the first command's parameter and removed a test environment's URL while I was at it (so the commands use similar values now).

Hope this helps. 🤠